### PR TITLE
Support for pushing notifications to JIRA on a deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,9 @@ The other feature is pushing your assets to a CDN using rsync. You can enable th
 
 You'll have to make sure that rsync can access your CDN without being prompter for a password.
 
+### JIRA
+
+If you use JIRA for issue tracking, you can update issues by referencing them in a deploy comment
 
 ### Benchmarking your deploys
 

--- a/lib/pd-cap-recipes/tasks/jira.rb
+++ b/lib/pd-cap-recipes/tasks/jira.rb
@@ -1,0 +1,60 @@
+Capistrano::Configuration.instance(:must_exist).load do |config|
+  namespace :email do
+    desc "Send email to JIRA via Mailgun SMTP"
+    task :notify_jira do
+      # This follows the same convention as cap_gun, and uses the prod config
+      # to figure out what creds to use with Mailgun.
+      mail_config = HashWithIndifferentAccess.new(YAML.load_file('config/drivers/mailgun.yml')['production']).symbolize_keys
+      Mail.defaults do
+        delivery_method :smtp, mail_config
+      end
+
+      as_user = jira_email
+      message = jira_message
+      jira_issues = find_jira_issues(message)
+      jira_issues.each do |issue|
+        puts 'Updating JIRA issue ' + issue + ' with this deploy note as ' + as_user
+        Mail.deliver do
+          to 'jira@pagerduty.atlassian.net'
+          from as_user
+          subject issue
+          body message
+        end
+      end
+    end
+  end
+
+  set :jira_message do
+    message = "#{jira_human} has deployed #{jira_deployment_name} to #{stage}.\n\n"
+    message << comment
+    message
+  end
+
+  def find_jira_issues(to_check)
+    to_check.scan(/[A-Z]{2,4}-[0-9]{1,5}/)
+  end
+
+  def jira_email
+    if (u = %x{git config user.email}.strip) =~ /pagerduty.com/
+      u
+    else
+      "jira@pagerduty.com"
+    end
+  end
+
+  def jira_deployment_name
+    if branch
+      "#{application}/#{branch}"
+    else
+      application
+    end
+  end
+
+  def jira_human
+    if (u = %x{git config user.name}.strip) != ""
+      u
+    else
+      "Someone"
+    end
+  end
+end

--- a/lib/pd-cap-recipes/tasks/jira.rb
+++ b/lib/pd-cap-recipes/tasks/jira.rb
@@ -48,7 +48,7 @@ Capistrano::Configuration.instance(:must_exist).load do |config|
   def find_jira_issues(to_check)
     # FYI: This regex tries to balance between the overly-broad standard JIRA issue
     # ID, and what is in common use.  (ABC-123, etc).  Improvements welcomed.
-    to_check.scan(/[A-Z]{2,4}-[0-9]{1,5}/)
+    to_check.scan(/[a-z,A-Z]{2,4}-[0-9]{1,5}/)
   end
 
   def jira_from_address

--- a/pd-cap-recipes.gemspec
+++ b/pd-cap-recipes.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "grit", ">= 2.5.0"
   s.add_dependency "git", ">= 1.2.5"
+  s.add_dependency "mail", ">= 2.5.3"
 
   # Also add these to your gem file
   # gem 'cap_gun', :git => "git://github.com/ffmike/cap_gun.git"

--- a/spec/jira_spec.rb
+++ b/spec/jira_spec.rb
@@ -1,0 +1,36 @@
+require 'spec_helper'
+
+describe "JIRA updates", :recipe => true, :tag => true do
+  it "should always define a valid From email address" do
+    config.jira_email.should match("([a-z,0-9].*)@pagerduty.com")
+  end
+
+  it "should always define a deployment name" do
+    config.jira_deployment_name
+  end
+
+  it "should always define a deployment human" do
+    config.jira_human
+  end
+
+  it "should find a JIRA issue when there is one" do
+    valid_messages = ['omg OPS-123',
+                      'OPS-123 bbq',
+                      'omg OPS-123 bbq',
+                      'OPS-123']
+
+    valid_messages.each do |msg|
+      config.find_jira_issues(msg).should have(1).items
+      config.find_jira_issues(msg).should include("OPS-123")
+    end
+
+    multiple_issues = "omg OPS-123 ENG-456 bbq"
+    config.find_jira_issues(multiple_issues).should have(2).items
+    config.find_jira_issues(multiple_issues).should include("OPS-123")
+    config.find_jira_issues(multiple_issues).should include("ENG-456")
+  end
+
+  it "should NOT find a JIRA issue when there isn't one" do
+    config.find_jira_issues("foo bar baz").should have(0).items
+  end
+end

--- a/spec/jira_spec.rb
+++ b/spec/jira_spec.rb
@@ -1,8 +1,15 @@
 require 'spec_helper'
 
 describe "JIRA updates", :recipe => true, :tag => true do
-  it "should always define a valid From email address" do
-    config.jira_email.should match("([a-z,0-9].*)@pagerduty.com")
+  before(:each) do
+    config.set :jira_from_domain, "example.com"
+    config.set :jira_default_from_address, "user@example.com"
+    config.set :jira_to_address, "jira@example.com"
+    config.set :stage, "testing"
+  end
+
+  it "should always define a From email address" do
+    config.jira_from_address.should eq("user@example.com")
   end
 
   it "should always define a deployment name" do


### PR DESCRIPTION
This is one half of the changes needed to support OPS-177 - pushing
updates to JIRA on a prod deploy.  (The other half will be modifying the
web repo to use what's in this commit).

Testing Done:

* bundle exec rspec spec/jira_spec.rb - OK
* bundle exec rspec - OK
* (in a modified web repo) cap preview email:notify_jira - OK