### PR TITLE
@danielribeiro @danmbyrd Prefixed git tag with readable timestamp for filtering and sorting.

### DIFF
--- a/lib/pd-cap-recipes/tasks/git.rb
+++ b/lib/pd-cap-recipes/tasks/git.rb
@@ -62,7 +62,7 @@ Capistrano::Configuration.instance(:must_exist).load do |config|
 
       git.fetch
 
-      new_tag = "#{repo.head.name}-#{Time.now.utc.to_i}"
+      new_tag = "deploy-#{Time.now.utc.strftime('%Y_%m_%d-%H_%M_%S')}-#{repo.head.name}"
       git.remote_tag new_tag
 
       Capistrano::CLI.ui.say "Your new tag is #{green new_tag}" 

--- a/lib/pd-cap-recipes/tasks/git.rb
+++ b/lib/pd-cap-recipes/tasks/git.rb
@@ -62,7 +62,7 @@ Capistrano::Configuration.instance(:must_exist).load do |config|
 
       git.fetch
 
-      new_tag = "deploy-#{Time.now.utc.strftime('%Y_%m_%d-%H_%M_%S')}-#{repo.head.name}"
+      new_tag = "cap-#{Time.now.utc.strftime('%Y%m%d_%H%M%S')}-#{repo.head.name}"
       git.remote_tag new_tag
 
       Capistrano::CLI.ui.say "Your new tag is #{green new_tag}" 


### PR DESCRIPTION
@danielribeiro @danmbyrd Prefixed git tag with readable timestamp for filtering and sorting.

Changes:
- The tag format is now "deploy-${yyyy_mm_dd-H_M_S}-${branchName}"
