### PR TITLE
bye bye active_support

### DIFF
--- a/lib/pd-cap-recipes/version.rb
+++ b/lib/pd-cap-recipes/version.rb
@@ -1,7 +1,7 @@
 module Pd
   module Cap
     module Recipes
-      VERSION = '0.3.0'
+      VERSION = '0.3.1'
     end
   end
 end

--- a/pd-cap-recipes.gemspec
+++ b/pd-cap-recipes.gemspec
@@ -27,5 +27,4 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'grit', '~> 2.5.0'
   s.add_runtime_dependency 'json'
   s.add_runtime_dependency 'mysql2'
-  s.add_runtime_dependency 'activesupport'
 end

--- a/spec/lingering_releases_spec.rb
+++ b/spec/lingering_releases_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+describe 'lingering_releases', recipe: true do
+  describe 'task execution' do
+    let(:task_lambda) { lambda { config.find_and_execute_task 'deploy:cleanup_lingering_releases' } }
+
+    it 'should not raise any errors' do
+      expect { task_lambda.call }.to_not raise_error
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,6 @@
 require 'capistrano'
 require 'capistrano/cli'
 require 'capistrano-spec'
-require 'active_support/all'
 
 module Capistrano::Spec::LoadTestRecipe
   def load_test_recipe


### PR DESCRIPTION
- add a smoke test for `lingering_releases` which just calls the task. just making sure task can be invoked.
- updated lingering_tasks to not use `.present?` which is an `active_support` method.
- remove `active_support` dependency from `gemspec`.

bumping version to `0.3.1`. i will create two releases once this is merged.
- `0.3.1` which includes rollback renaming and this.
- ~~`0.2.1` which only includes this.~~