### PR TITLE
bring back comments (with hipchat notification)

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,31 @@ Another nice thing this recipe does is keep an up to date tag for each environme
 
     git diff production
 
+### Deploy Comments
+
+In order to enable custom deploy comments which are sent via HipChat; you will need to follow these steps:
+
+1. If `hipchat` gem is not part of your project, add it. It's not part `pd-cap-recipes` since it's an optional feature. Last known good version is `1.4.0`. Basically, you need a version which supports the following functionality:
+
+  ```ruby
+  # hipchat.send
+  # hipchat.send_options
+  # https://github.com/hipchat/hipchat-rb/blob/master/lib/hipchat/capistrano2.rb
+  hipchat.send('deploying things', hipchat.send_options)
+  ```
+
+  ```ruby
+  gem 'hipchat', '~> 1.4.0'
+  ```
+
+2. Add a before hook in your deployment file.
+
+  ```ruby
+  before 'deploy', 'hipchat:custom_comment'
+  ```
+
+When you deploy, you will prompted for a comment. This will be used to notify your coworkers via HipChat.
+
 ### Improved Logging
 
 The entire output produced by capistrano is logged to `log/capistrano.log`.

--- a/lib/pd-cap-recipes/tasks/comments.rb
+++ b/lib/pd-cap-recipes/tasks/comments.rb
@@ -1,0 +1,51 @@
+COMMENT_FILE = "/var/tmp/cap_message.txt"
+
+Capistrano::Configuration.instance(:must_exist).load do |config|
+  namespace :hipchat do
+    task :custom_comment do
+      hipchat.send(comment, hipchat.send_options)
+    end
+  end
+
+  # Make sure that there's a comment for this deploy
+  set :comment do
+    unless config[:comment_value]
+      file = COMMENT_FILE
+      FileUtils.rm(file) if File.exists?(file)
+      if no_comment?
+        prev = safe_current_revision
+        cur = fetch(:branch)
+        content =
+"""
+
+# Please provide a meaningful comment describing what you are deploying.
+"""
+        File.open(file, 'w') do |f|
+          f.write(content)
+        end
+
+        if prev && cur
+          `git log #{prev}..#{cur} --pretty="# %h: %s" >> #{file}`
+        end
+
+        system("#{ENV['EDITOR'] || 'vim'} #{file}")
+        comment = File.exist?(file) ? File.open(file).read : nil
+
+        config[:comment_value] = clean_comment(comment)
+      end
+
+      if no_comment?
+        raise "You must specify a comment"
+      end
+    end
+    config[:comment_value]
+  end
+
+  def no_comment?
+    !exists?(:comment_value) || fetch(:comment_value).nil? || fetch(:comment_value).strip == ""
+  end
+
+  def clean_comment(comment)
+    comment.split("\n").reject{|line| /^\s*#.*$/ === line}.reject{|line| line.strip == ""}.join("\n")
+  end
+end

--- a/lib/pd-cap-recipes/version.rb
+++ b/lib/pd-cap-recipes/version.rb
@@ -1,7 +1,7 @@
 module Pd
   module Cap
     module Recipes
-      VERSION = '0.3.1'
+      VERSION = '0.3.2'
     end
   end
 end

--- a/spec/comment_spec.rb
+++ b/spec/comment_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+
+describe 'Commit comments', recipe: true do
+  describe 'without a current revision', tag: true do
+    before(:each) do
+      config.set :current_revision, lambda { raise 'Error' }
+      ENV['EDITOR'] = "echo 'Some comment' >> #{COMMENT_FILE}"
+    end
+
+    it 'should get comment without exception' do
+      expect { config.comment }.to_not raise_error
+    end
+  end
+end


### PR DESCRIPTION
- brought back `comments.rb`.
- added `hipchat:custom_comment` task which utilizes `hipchat` capistrano2 recipe methods (technically, they are not `private` or `protected`) to send custom messages about a deploy.
- updated `README` with instructions on how to integrate.
- bump version to `0.3.2`.