### PR TITLE
DEV-199 Update pd-cap-recipes to Skip Flags for Git and Hipchat

### DIFF
--- a/lib/pd-cap-recipes/tasks/comments.rb
+++ b/lib/pd-cap-recipes/tasks/comments.rb
@@ -3,13 +3,13 @@ COMMENT_FILE = "/var/tmp/cap_message.txt"
 Capistrano::Configuration.instance(:must_exist).load do |config|
   namespace :hipchat do
     task :custom_comment do
-      hipchat.send(comment, hipchat.send_options)
+      hipchat.send(comment, hipchat.send_options) unless fetch(:skip_hipchat, false)
     end
   end
 
   # Make sure that there's a comment for this deploy
   set :comment do
-    unless config[:comment_value]
+    unless config[:comment_value] || fetch(:skip_hipchat, false)
       file = COMMENT_FILE
       FileUtils.rm(file) if File.exists?(file)
       if no_comment?

--- a/lib/pd-cap-recipes/tasks/git.rb
+++ b/lib/pd-cap-recipes/tasks/git.rb
@@ -71,19 +71,21 @@ Capistrano::Configuration.instance(:must_exist).load do |config|
     end
 
     task :update_tag_for_stage do
-      git = GitRepo.new
-      env = config[:stage]
-
-      git.delete_remote_tag env
-      git.remote_tag env
-      git.remote_tag "DEPLOYED---#{env}---#{Time.now.utc.to_i}"
+      unless fetch(:skip_git, false)
+        git = GitRepo.new
+        env = config[:stage]
+  
+        git.delete_remote_tag env
+        git.remote_tag env
+        git.remote_tag "DEPLOYED---#{env}---#{Time.now.utc.to_i}"
+      end
     end
 
     task :validate_branch_is_tag do
       # Make sure an external recipe is not overriding the branch variable by
       # doing something like
       # set :branch, :master
-      if config[:branch] != config[:_git_branch]
+      if config[:branch] != config[:_git_branch] && !fetch(:skip_git, false)
         raise Capistrano::Error.new("The current branch do not seems to match the cached version. Make sure you are not overriding it in your config by doing something like 'set :deploy, 'release''")
       end
     end

--- a/lib/pd-cap-recipes/version.rb
+++ b/lib/pd-cap-recipes/version.rb
@@ -1,7 +1,7 @@
 module Pd
   module Cap
     module Recipes
-      VERSION = '0.4.0'
+      VERSION = '0.4.1'
     end
   end
 end


### PR DESCRIPTION
Adding code to skip doing tasks (tasks will still show as run in Cap output) when appropriate flags set.