### PR TITLE
DEV-152 Evaluate a cap slow deploy ability

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,14 @@ Another nice thing this recipe does is keep an up to date tag for each environme
 
     git diff production
 
+You can skip git integration altogether when needed using
+
+    $ bundle exec cap vagrant deploy -s skip_git=true
+
+or you could use set to selectively disable, useful if you have a local/dev environment you do not want to check:
+
+    set :skip_git, true
+
 ### Deploy Comments
 
 In order to enable custom deploy comments which are sent via HipChat; you will need to follow these steps:
@@ -71,6 +79,14 @@ In order to enable custom deploy comments which are sent via HipChat; you will n
 
 When you deploy, you will prompted for a comment. This will be used to notify your coworkers via HipChat.
 
+Like with the git integration, you can selectively disable this integration when/where needed:
+
+    $ bundle exec cap vagrant deploy -s skip_hipchat=true
+
+or...
+
+    set :skip_hipchat, true
+
 ### Improved Logging
 
 The entire output produced by capistrano is logged to `log/capistrano.log`.
@@ -88,6 +104,20 @@ There are some standard functions to colour your output, for example
     Capistrano::CLI.ui.say green "Nice job!"
   end
   ```
+
+### Deploy Slowly
+
+There is a task 'deploy:slow' that will cause deployment to be segregated into blocks, based on a percentage of target hosts. The percentage defaults to 10% rounding down, but can be set with the config value :slow_block_size:
+
+    $ bundle exec cap production deploy:slow -s slow_block_size=0.25
+
+or in code...
+
+    set :slow_block_size, 0.25
+
+If you have 100 machines it will start by deploying to 10, then to another 10 and thereon until all machines have been deployed to.
+
+    $ bundle exec cap production deploy:slow
 
 #License and Copyright
 Copyright (c) 2014, PagerDuty

--- a/lib/pd-cap-recipes/tasks/slow_deploy.rb
+++ b/lib/pd-cap-recipes/tasks/slow_deploy.rb
@@ -1,0 +1,19 @@
+Capistrano::Configuration.instance(:must_exist).load do |config|
+  namespace :deploy do
+    desc 'Release in percentage based blocks, defaulting blocks to (floor of) 10% of machines'
+    task :slow do
+      percentage = fetch(:slow_block_size, 0.10).to_f
+      if percentage < 0 || percentage > 1
+        raise "Please set slow_block_size to a percentage between 0.0 and 1.0"
+      end
+
+      server_count = find_servers_for_task(current_task).size
+      hosts = (server_count * percentage).floor
+      if hosts <= 0
+        hosts = 1
+      end
+      set :max_hosts, hosts
+      default # run default set of tasks (build, deploy, etc)
+    end
+  end
+end

--- a/lib/pd-cap-recipes/version.rb
+++ b/lib/pd-cap-recipes/version.rb
@@ -1,7 +1,7 @@
 module Pd
   module Cap
     module Recipes
-      VERSION = '0.4.1'
+      VERSION = '0.4.2'
     end
   end
 end


### PR DESCRIPTION
Adding a deploy:slow that merely sets max_hosts to floor of 1/10th of servers being used and then deploys as normal.