### PR TITLE
bump capistrano version to 2.15.6 (internal version)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,5 @@ source 'http://rubygems.org'
 
 # Specify your gem's dependencies in pd-cap-recipes.gemspec
 gemspec
+
+gem 'capistrano', '2.15.6', git: 'https://github.com/PagerDuty/capistrano.git', tag: 'v2.15.6'

--- a/lib/pd-cap-recipes/version.rb
+++ b/lib/pd-cap-recipes/version.rb
@@ -1,7 +1,7 @@
 module Pd
   module Cap
     module Recipes
-      VERSION = '0.4.7'
+      VERSION = '0.4.8'
     end
   end
 end

--- a/pd-cap-recipes.gemspec
+++ b/pd-cap-recipes.gemspec
@@ -24,7 +24,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'capistrano-spec', '~> 0.2.0'
   s.add_development_dependency 'rubocop'
 
-  s.add_runtime_dependency 'capistrano', '~> 2.15'
   s.add_runtime_dependency 'grit', '~> 2.5.0'
   s.add_runtime_dependency 'json'
 end


### PR DESCRIPTION
This bumps the version of `capistrano` that `pd-cap-recipes` depends on to `v2.15.6`. This is not a public release of Capistrano, and was released from our fork.

This version of capistrano includes a newer version of `net-ssh`.

In addition, revision number of `pd-cap-recipes` was bumped to `0.4.8`.