### PR TITLE
this edit was missed in #46 due to a missing git-add

### DIFF
--- a/lib/pd-cap-recipes/version.rb
+++ b/lib/pd-cap-recipes/version.rb
@@ -1,7 +1,7 @@
 module Pd
   module Cap
     module Recipes
-      VERSION = '0.4.8'
+      VERSION = '0.4.9'
     end
   end
 end

--- a/pd-cap-recipes.gemspec
+++ b/pd-cap-recipes.gemspec
@@ -25,5 +25,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rubocop'
 
   s.add_runtime_dependency 'grit', '~> 2.5.0'
+  s.add_runtime_dependency 'capistrano', '2.15.6'
   s.add_runtime_dependency 'json'
 end


### PR DESCRIPTION
This should pin the capistrano version to 2.15.6.