### PR TITLE
bump capistrano version fo 2.15.7 (internal build)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,4 +3,4 @@ source 'http://rubygems.org'
 # Specify your gem's dependencies in pd-cap-recipes.gemspec
 gemspec
 
-gem 'capistrano', '2.15.6', git: 'https://github.com/PagerDuty/capistrano.git', tag: 'v2.15.6'
+gem 'capistrano', '2.15.7', git: 'https://github.com/PagerDuty/capistrano.git', tag: 'v2.15.7'

--- a/pd-cap-recipes.gemspec
+++ b/pd-cap-recipes.gemspec
@@ -25,6 +25,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rubocop'
 
   s.add_runtime_dependency 'grit', '~> 2.5.0'
-  s.add_runtime_dependency 'capistrano', '2.15.6'
+  s.add_runtime_dependency 'capistrano', '2.15.7'
   s.add_runtime_dependency 'json'
 end


### PR DESCRIPTION
This bumps the capistrano version to 2.15.7 which includes a fix for the SSH NAT timeout issue thanks to @evan2645.