### PR TITLE
Dont force cutting tags as part of deployment

### DIFF
--- a/lib/pd-cap-recipes/tasks/git.rb
+++ b/lib/pd-cap-recipes/tasks/git.rb
@@ -124,8 +124,6 @@ Capistrano::Configuration.instance(:must_exist).load do |config|
     end
   end
 
-  after 'deploy_previous_tag', 'deploy'
-
   # NOTE: not being used as far as we can tell
   desc 'Rollback to the previous git tag deployed by performing a regular deploy.'
   task :deploy_previous_tag do
@@ -138,10 +136,6 @@ Capistrano::Configuration.instance(:must_exist).load do |config|
     Capistrano::CLI.ui.say "Rolling back to #{tag_to_rollback_to}"
     config[:tag] = tag_to_rollback_to
   end
-
-  after "deploy:create_symlink", "git:update_tag_for_stage"
-  before "deploy", "git:validate_branch_is_tag"
-  before "deploy:migrations", "git:validate_branch_is_tag"
 
   namespace :git do
 

--- a/lib/pd-cap-recipes/tasks/reports.rb
+++ b/lib/pd-cap-recipes/tasks/reports.rb
@@ -51,7 +51,6 @@ Capistrano::Configuration.instance(:must_exist).load do |config|
           rev_info.each do |host, rev|
             puts "#{host} -> #{rev}"
           end
-          return
         end
 
         puts "The current revision installed on #{rev_info.keys.length} machines is '#{revs.first}'"

--- a/spec/git_spec.rb
+++ b/spec/git_spec.rb
@@ -23,12 +23,6 @@ describe "Git sanity check", :recipe => true do
         config.set :reverse_deploy_ok, true
         expect(task_lambda).to_not raise_error
       end
-
-      ["deploy", "deploy:migrations"].each do |task|
-        it "should run before #{task}" do
-          expect(before_callbacks_for_task(task)).to include('git:validate_branch_is_tag')
-        end
-      end
     end
 
     describe 'without a current revision' do


### PR DESCRIPTION
We want to deploy every commit, automatically via CI/CD system. But currently pd-cap-recipes enforces cutting tag for every deploy. This changeset keeps that feature, but instead of forcing it, let consumers configure it.