### PR TITLE
(bug)dont use return in tasks as they are instance evaled.

### DIFF
--- a/lib/pd-cap-recipes/tasks/git.rb
+++ b/lib/pd-cap-recipes/tasks/git.rb
@@ -153,13 +153,12 @@ Capistrano::Configuration.instance(:must_exist).load do |config|
     #
     # You may deploy and then have no REVISION file yet which means this fails.
     set :branch do
-      return config[:_git_branch] if config[:_git_branch]
-
-      # if tag is provided (e.g. -s tag=master-1234567890), use it. otherwise, cut a new tag.
-      tag = config[:tag] || git_cut_tag
-      config[:_git_branch] = tag
-      git_sanity_check(tag)
-
+      unless config[:_git_branch]
+        # if tag is provided (e.g. -s tag=master-1234567890), use it. otherwise, cut a new tag.
+        tag = config[:tag] || git_cut_tag
+        config[:_git_branch] = tag
+        git_sanity_check(tag)
+      end
       config[:_git_branch]
     end
 


### PR DESCRIPTION
 It causes local jump errors: https://dev-build.pd-internal.com/go/tab/build/detail/EventTransformer/15/CanaryDeploy/1/Deploy