### PR TITLE
Make sure to default to 22, as capistrano doesn't keep record when it…

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,12 @@ or...
 
     set :skip_hipchat, true
 
+### Non-Standard SSH Port
+
+If you are using a port other than 22 for ssh on your machine you will want to
+configure this by setting the port value in the deploy file. For example
+```set :port, 10022```.
+
 ### Improved Logging
 
 The entire output produced by capistrano is logged to `log/capistrano.log`.

--- a/lib/pd-cap-recipes/tasks/reports.rb
+++ b/lib/pd-cap-recipes/tasks/reports.rb
@@ -7,7 +7,7 @@ def get_connection_details
   servers = find_servers_for_task(current_task)
   user = fetch(:user)
   deploy_to = fetch(:deploy_to)
-  port = fetch(:port)
+  port = fetch(:port, 22)
   gateway_host = nil
   begin
     gateway_config = fetch(:gateway)


### PR DESCRIPTION
…'s default

When you do not specify an override port, capistrano will not have a value for the port so we need to default to 22.