### PR TITLE
Only say that all servers are on the same version if they are.

### DIFF
--- a/lib/pd-cap-recipes/tasks/reports.rb
+++ b/lib/pd-cap-recipes/tasks/reports.rb
@@ -52,6 +52,7 @@ Capistrano::Configuration.instance(:must_exist).load do |config|
           rev_info.each do |host, rev|
             puts "#{host} -> #{rev}"
           end
+          next
         end
 
         puts "The current revision installed on #{rev_info.keys.length} machines is '#{revs.first}'"

--- a/lib/pd-cap-recipes/version.rb
+++ b/lib/pd-cap-recipes/version.rb
@@ -1,7 +1,7 @@
 module Pd
   module Cap
     module Recipes
-      VERSION = '0.6.1'
+      VERSION = '0.6.2'
     end
   end
 end


### PR DESCRIPTION
Previously, after discovering that not all hosts were running the same revision, we were still outputting the message "The current revision installed on N machines is abc123", where N is the total number of hosts. This changeset fixes that by skipping to the next task if deployed revisions are not homogeneous.

@robottaway any suggestions how to test this?