### PR TITLE
Allow tagging of non origin remote

### DIFF
--- a/lib/pd-cap-recipes/classes/git_repo.rb
+++ b/lib/pd-cap-recipes/classes/git_repo.rb
@@ -82,4 +82,16 @@ class GitRepo
     end
     return true
   end
+
+  def preferred_remote
+    remotes = @repo.config.keys
+      .select { |k| k.start_with? 'remote.' }
+      .map { |r| r.split('.')[1] }
+      .sort.uniq
+    if remotes.size == 1
+      remotes.first
+    else
+      'origin'
+    end
+  end
 end

--- a/lib/pd-cap-recipes/classes/git_repo.rb
+++ b/lib/pd-cap-recipes/classes/git_repo.rb
@@ -10,14 +10,14 @@ class GitRepo
     @git.__send__(*args, &block)
   end
 
-  def delete_remote_tag(tag)
+  def delete_remote_tag(tag, remote='origin')
     @git.tag d: tag
-    @git.push({raise: true}, 'origin', ":refs/tags/#{tag}")
+    @git.push({raise: true}, remote, ":refs/tags/#{tag}")
   end
 
-  def remote_tag(tag)
+  def remote_tag(tag, remote='origin')
     @git.tag({raise: true}, tag)
-    @git.push({raise: true}, 'origin', "refs/tags/#{tag}")
+    @git.push({raise: true}, remote, "refs/tags/#{tag}")
   end
 
   # Fetch latest from origin and check given hash exists in origin

--- a/lib/pd-cap-recipes/classes/git_repo.rb
+++ b/lib/pd-cap-recipes/classes/git_repo.rb
@@ -1,0 +1,85 @@
+require 'grit'
+
+class GitRepo
+  def initialize()
+    @git = Grit::Git.new(File.join('.', '.git'))
+    @repo = Grit::Repo.new('.')
+  end
+
+  def method_missing(*args, &block)
+    @git.__send__(*args, &block)
+  end
+
+  def delete_remote_tag(tag)
+    @git.tag d: tag
+    @git.push({raise: true}, 'origin', ":refs/tags/#{tag}")
+  end
+
+  def remote_tag(tag)
+    @git.tag({raise: true}, tag)
+    @git.push({raise: true}, 'origin', "refs/tags/#{tag}")
+  end
+
+  # Fetch latest from origin and check given hash exists in origin
+  def check_tag_exists_in_origin(tag, origin_name='origin')
+    raise "invalid tag: #{string.inspect}" unless string.is_a?(String)
+    hash = @git.rev_parse({raise: true}, tag)
+    output = @git.ls_remote({raise: true}, origin_name, "refs/tags/#{tag}")
+    if output =~ /#{hash}\s*refs\/tags\/#{tag}/
+      return true
+    end
+    return false
+  end
+
+  # return Grit::Head object or nil if in detached state
+  def head
+    return @repo.head
+  end
+
+  # return the latest commit's hash
+  def get_hash(commitish='HEAD', opts={raise: true})
+    commitish = commitish.to_s
+    return @git.rev_parse(opts, commitish).chomp
+  end
+
+  # Get the first eight characters of commit hash for given tag, branch or hash
+  def get_short_hash(commitish='HEAD')
+    commitish = commitish.to_s
+    return get_hash(commitish)[0,8]
+  end
+
+  def current_branch
+    return @git.run('', 'rev-parse', '', {}, ['--abbrev-ref', 'HEAD']).chomp
+  end
+
+  # Return array of "<remote>/<branch>" values containing given commit hash
+  def remote_branches_containing(hash)
+    return @git.run('', 'branch', '', {}, ['-r', '--contains', hash])
+  end
+
+  # get the hash for branch/tag in the remote origin
+  def has_remote?(commitish, origin_name='origin')
+    commitish = commitish.to_s
+    output = @git.ls_remote({raise: true}, origin_name)
+    output.split.each do |line|
+      if line=~ /[a-z0-9]{40}\s*refs\/(tags|heads)\/#{commitish}/
+        return true
+      end
+    end
+    return nil
+  end
+
+  def head_detached?
+    if @repo.head == nil
+      return true
+    end
+    return false
+  end
+
+  def has_local_modifications?
+    if @git.status({raise: true}, '--porcelain') == ''
+      return false
+    end
+    return true
+  end
+end

--- a/lib/pd-cap-recipes/classes/git_repo.rb
+++ b/lib/pd-cap-recipes/classes/git_repo.rb
@@ -1,7 +1,8 @@
 require 'grit'
 
+# Convenience wrapper around Grit::Git
 class GitRepo
-  def initialize()
+  def initialize
     @git = Grit::Git.new(File.join('.', '.git'))
     @repo = Grit::Repo.new('.')
   end
@@ -25,36 +26,33 @@ class GitRepo
     raise "invalid tag: #{string.inspect}" unless string.is_a?(String)
     hash = @git.rev_parse({raise: true}, tag)
     output = @git.ls_remote({raise: true}, origin_name, "refs/tags/#{tag}")
-    if output =~ /#{hash}\s*refs\/tags\/#{tag}/
-      return true
-    end
-    return false
+    output =~ /#{hash}\s*refs\/tags\/#{tag}/
   end
 
   # return Grit::Head object or nil if in detached state
   def head
-    return @repo.head
+    @repo.head
   end
 
   # return the latest commit's hash
   def get_hash(commitish='HEAD', opts={raise: true})
     commitish = commitish.to_s
-    return @git.rev_parse(opts, commitish).chomp
+    @git.rev_parse(opts, commitish).chomp
   end
 
   # Get the first eight characters of commit hash for given tag, branch or hash
   def get_short_hash(commitish='HEAD')
     commitish = commitish.to_s
-    return get_hash(commitish)[0,8]
+    get_hash(commitish)[0, 8]
   end
 
   def current_branch
-    return @git.run('', 'rev-parse', '', {}, ['--abbrev-ref', 'HEAD']).chomp
+    @git.run('', 'rev-parse', '', {}, ['--abbrev-ref', 'HEAD']).chomp
   end
 
   # Return array of "<remote>/<branch>" values containing given commit hash
   def remote_branches_containing(hash)
-    return @git.run('', 'branch', '', {}, ['-r', '--contains', hash])
+    @git.run('', 'branch', '', {}, ['-r', '--contains', hash])
   end
 
   # get the hash for branch/tag in the remote origin
@@ -66,32 +64,34 @@ class GitRepo
         return true
       end
     end
-    return nil
+    nil
   end
 
   def head_detached?
-    if @repo.head == nil
-      return true
-    end
-    return false
+    @repo.head.nil?
   end
 
+  # rubocop:disable Style/PredicateName
   def has_local_modifications?
-    if @git.status({raise: true}, '--porcelain') == ''
-      return false
-    end
-    return true
+    @git.status({raise: true}, '--porcelain') != ''
   end
+  # rubocop:enable Style/PredicateName
 
   def preferred_remote
-    remotes = @repo.config.keys
-      .select { |k| k.start_with? 'remote.' }
-      .map { |r| r.split('.')[1] }
-      .sort.uniq
+    remotes = remote_names
     if remotes.size == 1
       remotes.first
     else
       'origin'
     end
+  end
+
+  private
+
+  def remote_names
+    @repo.config.keys
+      .select { |k| k.start_with? 'remote.' }
+      .map { |r| r.split('.')[1] }
+      .sort.uniq
   end
 end

--- a/lib/pd-cap-recipes/classes/git_repo.rb
+++ b/lib/pd-cap-recipes/classes/git_repo.rb
@@ -28,10 +28,10 @@ class GitRepo
   # Fetch latest from origin and check given hash exists in origin
   def check_tag_exists_in_origin(tag)
     origin_name = preferred_remote
-    raise "invalid tag: #{string.inspect}" unless string.is_a?(String)
+    fail "invalid tag: #{string.inspect}" unless string.is_a?(String)
     hash = @git.rev_parse({raise: true}, tag)
     output = @git.ls_remote({raise: true}, origin_name, "refs/tags/#{tag}")
-    output =~ /#{hash}\s*refs\/tags\/#{tag}/
+    output =~ %r{#{hash}\s*refs/tags/#{tag}}
   end
 
   # return Grit::Head object or nil if in detached state
@@ -61,14 +61,12 @@ class GitRepo
   end
 
   # get the hash for branch/tag in the remote origin
-  def has_remote?(commitish)
+  def remote?(commitish)
     origin_name = preferred_remote
     commitish = commitish.to_s
     output = @git.ls_remote({raise: true}, origin_name)
     output.split.each do |line|
-      if line=~ /[a-z0-9]{40}\s*refs\/(tags|heads)\/#{commitish}/
-        return true
-      end
+      return true if line =~ %r{[a-z0-9]{40}\s*refs/(tags|heads)/#{commitish}}
     end
     nil
   end

--- a/lib/pd-cap-recipes/tasks/git.rb
+++ b/lib/pd-cap-recipes/tasks/git.rb
@@ -8,12 +8,13 @@ Grit::Git.git_max_size = 104857600 # 100 megs
 # Create a new tag using the name of current branch and a UTC timestamp, then
 # push code & tag to remote.
 def git_cut_tag(git=GitRepo.new)
+  remote = 'origin'
   if git.head_detached?
     raise 'You are currently in a detached head state. Cannot cut tag.'
   end
   new_tag = "#{git.head.name}-#{Time.now.utc.to_i}"
   git.fetch
-  git.remote_tag new_tag
+  git.remote_tag new_tag, remote
   return new_tag
 end
 

--- a/lib/pd-cap-recipes/tasks/git.rb
+++ b/lib/pd-cap-recipes/tasks/git.rb
@@ -1,92 +1,9 @@
 require 'grit'
+require 'pd-cap-recipes/classes/git_repo'
 
 # Bump up grit limits since git.fetch can take a lot
 Grit::Git.git_timeout = 600 # seconds
 Grit::Git.git_max_size = 104857600 # 100 megs
-
-class GitRepo
-  def initialize()
-    @git = Grit::Git.new(File.join('.', '.git'))
-    @repo = Grit::Repo.new('.')
-  end
-
-  def method_missing(*args, &block)
-    @git.__send__(*args, &block)
-  end
-
-  def delete_remote_tag(tag)
-    @git.tag d: tag
-    @git.push({raise: true}, 'origin', ":refs/tags/#{tag}")
-  end
-
-  def remote_tag(tag)
-    @git.tag({raise: true}, tag)
-    @git.push({raise: true}, 'origin', "refs/tags/#{tag}")
-  end
-
-  # Fetch latest from origin and check given hash exists in origin
-  def check_tag_exists_in_origin(tag, origin_name='origin')
-    raise "invalid tag: #{string.inspect}" unless string.is_a?(String)
-    hash = @git.rev_parse({raise: true}, tag)
-    output = @git.ls_remote({raise: true}, origin_name, "refs/tags/#{tag}")
-    if output =~ /#{hash}\s*refs\/tags\/#{tag}/
-      return true
-    end
-    return false
-  end
-
-  # return Grit::Head object or nil if in detached state
-  def head
-    return @repo.head
-  end
-
-  # return the latest commit's hash
-  def get_hash(commitish='HEAD', opts={raise: true})
-    commitish = commitish.to_s
-    return @git.rev_parse(opts, commitish).chomp
-  end
-
-  # Get the first eight characters of commit hash for given tag, branch or hash
-  def get_short_hash(commitish='HEAD')
-    commitish = commitish.to_s
-    return get_hash(commitish)[0,8]
-  end
-
-  def current_branch
-    return @git.run('', 'rev-parse', '', {}, ['--abbrev-ref', 'HEAD']).chomp
-  end
-
-  # Return array of "<remote>/<branch>" values containing given commit hash
-  def remote_branches_containing(hash)
-    return @git.run('', 'branch', '', {}, ['-r', '--contains', hash])
-  end
-
-  # get the hash for branch/tag in the remote origin
-  def has_remote?(commitish, origin_name='origin')
-    commitish = commitish.to_s
-    output = @git.ls_remote({raise: true}, origin_name)
-    output.split.each do |line|
-      if line=~ /[a-z0-9]{40}\s*refs\/(tags|heads)\/#{commitish}/
-        return true
-      end
-    end
-    return nil
-  end
-
-  def head_detached?
-    if @repo.head == nil
-      return true
-    end
-    return false
-  end
-
-  def has_local_modifications?
-    if @git.status({raise: true}, '--porcelain') == ''
-      return false
-    end
-    return true
-  end
-end
 
 # Create a new tag using the name of current branch and a UTC timestamp, then
 # push code & tag to remote.

--- a/lib/pd-cap-recipes/tasks/git.rb
+++ b/lib/pd-cap-recipes/tasks/git.rb
@@ -8,13 +8,12 @@ Grit::Git.git_max_size = 104857600 # 100 megs
 # Create a new tag using the name of current branch and a UTC timestamp, then
 # push code & tag to remote.
 def git_cut_tag(git=GitRepo.new)
-  remote = 'origin'
   if git.head_detached?
     raise 'You are currently in a detached head state. Cannot cut tag.'
   end
   new_tag = "#{git.head.name}-#{Time.now.utc.to_i}"
   git.fetch
-  git.remote_tag new_tag, remote
+  git.remote_tag new_tag, git.preferred_remote
   return new_tag
 end
 
@@ -82,7 +81,6 @@ Capistrano::Configuration.instance(:must_exist).load do |config|
 
     # NOTE: looking at projects in Github I'm not seeing these tags.
     task :update_tag_for_stage do
-      remote = 'origin'
       skip_git = fetch(:skip_git, false)
       if skip_git
         Capistrano::CLI.ui.say yellow "Skipping update_tag_for_stage as 'skip_git' option is enabled"
@@ -93,6 +91,7 @@ Capistrano::Configuration.instance(:must_exist).load do |config|
       git = GitRepo.new
       env = config[:stage]
 
+      remote = git.preferred_remote
       git.delete_remote_tag env, remote
       git.remote_tag env, remote
       git.remote_tag "DEPLOYED---#{env}---#{Time.now.utc.to_i}", remote

--- a/lib/pd-cap-recipes/tasks/git.rb
+++ b/lib/pd-cap-recipes/tasks/git.rb
@@ -82,6 +82,7 @@ Capistrano::Configuration.instance(:must_exist).load do |config|
 
     # NOTE: looking at projects in Github I'm not seeing these tags.
     task :update_tag_for_stage do
+      remote = 'origin'
       skip_git = fetch(:skip_git, false)
       if skip_git
         Capistrano::CLI.ui.say yellow "Skipping update_tag_for_stage as 'skip_git' option is enabled"
@@ -91,10 +92,10 @@ Capistrano::Configuration.instance(:must_exist).load do |config|
       logger.important("Updating the tag for stage #{stage}")
       git = GitRepo.new
       env = config[:stage]
-  
-      git.delete_remote_tag env
-      git.remote_tag env
-      git.remote_tag "DEPLOYED---#{env}---#{Time.now.utc.to_i}"
+
+      git.delete_remote_tag env, remote
+      git.remote_tag env, remote
+      git.remote_tag "DEPLOYED---#{env}---#{Time.now.utc.to_i}", remote
     end
 
     task :validate_branch_is_tag do

--- a/lib/pd-cap-recipes/tasks/git.rb
+++ b/lib/pd-cap-recipes/tasks/git.rb
@@ -13,7 +13,7 @@ def git_cut_tag(git=GitRepo.new)
   end
   new_tag = "#{git.head.name}-#{Time.now.utc.to_i}"
   git.fetch
-  git.remote_tag new_tag, git.preferred_remote
+  git.remote_tag new_tag
   return new_tag
 end
 
@@ -91,10 +91,9 @@ Capistrano::Configuration.instance(:must_exist).load do |config|
       git = GitRepo.new
       env = config[:stage]
 
-      remote = git.preferred_remote
-      git.delete_remote_tag env, remote
-      git.remote_tag env, remote
-      git.remote_tag "DEPLOYED---#{env}---#{Time.now.utc.to_i}", remote
+      git.delete_remote_tag env
+      git.remote_tag env
+      git.remote_tag "DEPLOYED---#{env}---#{Time.now.utc.to_i}"
     end
 
     task :validate_branch_is_tag do

--- a/spec/classes/git_repo_spec.rb
+++ b/spec/classes/git_repo_spec.rb
@@ -1,0 +1,29 @@
+require 'rspec'
+require 'pd-cap-recipes/classes/git_repo'
+
+describe(GitRepo) do
+  subject { GitRepo.new }
+  let(:git) { double(Grit::Git).as_null_object }
+  let(:tag) { 'xyz' }
+  before(:each) do
+    allow(Grit::Git).to receive(:new).and_return(git)
+  end
+
+  describe('#remote_tag') do
+    it 'by default pushes a tag to origin' do
+      expect(git).to receive(:tag).with(anything, tag)
+      expect(git).to receive(:push)
+        .with(anything, 'origin', "refs/tags/#{tag}")
+      subject.remote_tag(tag)
+    end
+  end
+
+  describe('#delete_remote_tag') do
+    it 'by default deletes tag at origin' do
+      expect(git).to receive(:tag).with(d: tag)
+      expect(git).to receive(:push)
+        .with(anything, 'origin', ":refs/tags/#{tag}")
+      subject.delete_remote_tag(tag)
+    end
+  end
+end

--- a/spec/classes/git_repo_spec.rb
+++ b/spec/classes/git_repo_spec.rb
@@ -45,7 +45,7 @@ describe(GitRepo) do
         "remote.slurp.url",
         "remote.slurp.fetch",
         "branch.master.remote",
-        "branch.master.merge",
+        "branch.master.merge"
       ]
     end
     let(:repo) { instance_double(Grit::Repo) }
@@ -66,7 +66,7 @@ describe(GitRepo) do
     describe('when multiple remotes') do
       it 'returns origin' do
         allow(config).to receive(:keys).and_return(
-          config_keys + [ "remote.abc.url", "remote.abc.fetch" ]
+          config_keys + ["remote.abc.url", "remote.abc.fetch"]
         )
         expect(subject.preferred_remote).to eq('origin')
       end

--- a/spec/classes/git_repo_spec.rb
+++ b/spec/classes/git_repo_spec.rb
@@ -34,4 +34,42 @@ describe(GitRepo) do
       subject.delete_remote_tag(tag, 'stompy')
     end
   end
+
+  describe('#preferred_remote') do
+    let(:config_keys) do
+      # Partial list from `Grit::Repo.new('.').config.keys`
+      [
+        "user.email",
+        "fetch.prune",
+        "core.repositoryformatversion",
+        "remote.slurp.url",
+        "remote.slurp.fetch",
+        "branch.master.remote",
+        "branch.master.merge",
+      ]
+    end
+    let(:repo) { instance_double(Grit::Repo) }
+    let(:config) { instance_double(Grit::Config) }
+    subject { GitRepo.new }
+
+    before(:each) do
+      allow(Grit::Repo).to receive(:new).and_return(repo)
+      allow(repo).to receive(:config).and_return(config)
+    end
+
+    describe('when only one remote') do
+      it 'returns that remote' do
+        allow(config).to receive(:keys).and_return(config_keys)
+        expect(subject.preferred_remote).to eq('slurp')
+      end
+    end
+    describe('when multiple remotes') do
+      it 'returns origin' do
+        allow(config).to receive(:keys).and_return(
+          config_keys + [ "remote.abc.url", "remote.abc.fetch" ]
+        )
+        expect(subject.preferred_remote).to eq('origin')
+      end
+    end
+  end
 end

--- a/spec/classes/git_repo_spec.rb
+++ b/spec/classes/git_repo_spec.rb
@@ -16,6 +16,10 @@ describe(GitRepo) do
         .with(anything, 'origin', "refs/tags/#{tag}")
       subject.remote_tag(tag)
     end
+    it 'allows remote to be overridden' do
+      expect(git).to receive(:push) .with(anything, 'stompy', anything)
+      subject.remote_tag(tag, 'stompy')
+    end
   end
 
   describe('#delete_remote_tag') do
@@ -24,6 +28,10 @@ describe(GitRepo) do
       expect(git).to receive(:push)
         .with(anything, 'origin', ":refs/tags/#{tag}")
       subject.delete_remote_tag(tag)
+    end
+    it 'allows remote to be overridden' do
+      expect(git).to receive(:push) .with(anything, 'stompy', anything)
+      subject.delete_remote_tag(tag, 'stompy')
     end
   end
 end

--- a/spec/classes/git_repo_spec.rb
+++ b/spec/classes/git_repo_spec.rb
@@ -10,28 +10,21 @@ describe(GitRepo) do
   end
 
   describe('#remote_tag') do
-    it 'by default pushes a tag to origin' do
+    it 'pushes tag to preferred remote' do
       expect(git).to receive(:tag).with(anything, tag)
-      expect(git).to receive(:push)
-        .with(anything, 'origin', "refs/tags/#{tag}")
+      expect(git).to receive(:push).with(anything, 'slurp', "refs/tags/#{tag}")
+
+      subject.preferred_remote = 'slurp'
       subject.remote_tag(tag)
-    end
-    it 'allows remote to be overridden' do
-      expect(git).to receive(:push) .with(anything, 'stompy', anything)
-      subject.remote_tag(tag, 'stompy')
     end
   end
 
   describe('#delete_remote_tag') do
-    it 'by default deletes tag at origin' do
+    it 'deletes tag on preferred–remote' do
       expect(git).to receive(:tag).with(d: tag)
-      expect(git).to receive(:push)
-        .with(anything, 'origin', ":refs/tags/#{tag}")
+      expect(git).to receive(:push).with(anything, 'slurp', ":refs/tags/#{tag}")
+      subject.preferred_remote = 'slurp'
       subject.delete_remote_tag(tag)
-    end
-    it 'allows remote to be overridden' do
-      expect(git).to receive(:push) .with(anything, 'stompy', anything)
-      subject.delete_remote_tag(tag, 'stompy')
     end
   end
 
@@ -56,7 +49,12 @@ describe(GitRepo) do
       allow(Grit::Repo).to receive(:new).and_return(repo)
       allow(repo).to receive(:config).and_return(config)
     end
-
+    describe('when preferred_remote is set') do
+      it 'returns that it is set to' do
+        subject.preferred_remote = 'sloop'
+        expect(subject.preferred_remote).to eq('sloop')
+      end
+    end
     describe('when only one remote') do
       it 'returns that remote' do
         allow(config).to receive(:keys).and_return(config_keys)

--- a/spec/git_spec.rb
+++ b/spec/git_spec.rb
@@ -37,3 +37,14 @@ describe "Git sanity check", :recipe => true do
   end
 end
 
+describe 'git_cut_tag' do
+  let(:head) { double('head', name: :stompy) }
+  let(:git_repo) do
+    double(GitRepo, head_detached?: false, head: head, fetch: nil)
+  end
+  it 'pushes a new tag to origin by default' do
+    expect(git_repo).to receive(:remote_tag)
+      .with(anything, 'origin')
+    git_cut_tag(git_repo)
+  end
+end

--- a/spec/git_spec.rb
+++ b/spec/git_spec.rb
@@ -42,9 +42,10 @@ describe 'git_cut_tag' do
   let(:git_repo) do
     double(GitRepo, head_detached?: false, head: head, fetch: nil)
   end
-  it 'pushes a new tag to origin by default' do
+  it 'pushes a new tag to remote' do
+    allow(git_repo).to receive(:preferred_remote).and_return('stompy')
     expect(git_repo).to receive(:remote_tag)
-      .with(anything, 'origin')
+      .with(anything, 'stompy')
     git_cut_tag(git_repo)
   end
 end
@@ -59,14 +60,15 @@ describe 'update_tag_for_stage task', recipe: true do
     lambda { config.find_and_execute_task 'git:update_tag_for_stage' }
   end
 
-  it "updates tag on origin and adds deployment tag" do
+  it "updates tag on remote and adds deployment tag" do
     config.set :stage, stage
     allow(Time).to receive(:now).and_return(Time.utc(1970))
 
-    expect(git_repo).to receive(:delete_remote_tag).with(stage, 'origin')
-    expect(git_repo).to receive(:remote_tag).with(stage, 'origin')
+    allow(git_repo).to receive(:preferred_remote).and_return('stompy')
+    expect(git_repo).to receive(:delete_remote_tag).with(stage, 'stompy')
+    expect(git_repo).to receive(:remote_tag).with(stage, 'stompy')
     expect(git_repo).to receive(:remote_tag)
-      .with("DEPLOYED---#{stage}---0", 'origin')
+      .with("DEPLOYED---#{stage}---0", 'stompy')
     expect(update_tag_for_stage).to_not raise_error
   end
 end


### PR DESCRIPTION
This PR does 2 things:

- Moves the GitRepo class into its own file, adds tests for a couple of the methods, adds tests for a couple git capistrano tasks
- Adds a bit of logic to the GitRepo class to determine what remote should be pushed to

DEVREQ-3