### PR TITLE
DEV-676 Fix missing imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.6.4
+
+Fix missing imports in lib/pd-cap-recipes/pd_slack.rb module.
+* [DEV-676](https://pagerduty.atlassian.net/browse/DEV-676)
+
 ## 0.6.3
 
 Fix bug with missing require for set

--- a/lib/pd-cap-recipes/pd_slack.rb
+++ b/lib/pd-cap-recipes/pd_slack.rb
@@ -1,4 +1,6 @@
 require 'json'
+require 'uri'
+require 'net/http'
 
 module PdSlack
   class InvalidElement < StandardError

--- a/lib/pd-cap-recipes/version.rb
+++ b/lib/pd-cap-recipes/version.rb
@@ -1,7 +1,7 @@
 module Pd
   module Cap
     module Recipes
-      VERSION = '0.6.3'
+      VERSION = '0.6.4'
     end
   end
 end


### PR DESCRIPTION
So I found a few more things that where missing import related. Annoyed the UTs didn't catch this. Seems the only time we touched the classes where using mocks which don't assert the real package is installed.