### PR TITLE
Allow production rollbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.5
+
+Remove restriction on non-production rollbacks in favor of letting individual service owners decide whether to enforce this.
+
 ## 0.6.4
 
 Fix missing imports in lib/pd-cap-recipes/pd_slack.rb module.

--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,5 @@ source 'http://rubygems.org'
 gemspec
 
 gem 'capistrano', '2.15.7', git: 'https://github.com/PagerDuty/capistrano.git', tag: 'v2.15.7'
+gem 'rake', '10.5.0'
+gem 'rubocop', '0.37.0'

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -7,7 +7,7 @@ First make sure that the PR you are about to merge into master meets the followi
 * You have updated the [CHANGELOG.md](CHANGELOG.md) file to contain information on changes in the release.
 *
 
-Next merge the PR and delete the branch you where using.
+Next merge the PR and delete the branch you were using.
 
 Create a tag for the version, the format is v1.2.3, you can do this by using the release function in GitHub.
 

--- a/lib/pd-cap-recipes/tasks/git.rb
+++ b/lib/pd-cap-recipes/tasks/git.rb
@@ -152,9 +152,9 @@ Capistrano::Configuration.instance(:must_exist).load do |config|
     return false
   end
 
-  # If we are in a non-Production environment and we have enabled it allow reverse deploy
+  # Allow reverse deploy if we have enabled it
   def reverse_ok
-    return (ENV['REVERSE_DEPLOY_OK'] || fetch(:reverse_deploy_ok, false)) && fetch(:stage) != 'production'
+    return ENV['REVERSE_DEPLOY_OK'] || fetch(:reverse_deploy_ok, false)
   end
 
   def confirm(msg)

--- a/lib/pd-cap-recipes/version.rb
+++ b/lib/pd-cap-recipes/version.rb
@@ -1,7 +1,7 @@
 module Pd
   module Cap
     module Recipes
-      VERSION = '0.6.4'
+      VERSION = '0.6.5'
     end
   end
 end

--- a/pd-cap-recipes.gemspec
+++ b/pd-cap-recipes.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'rspec-core'
   s.add_development_dependency 'capistrano-spec', '~> 0.2.0'
-  s.add_development_dependency 'rubocop'
+  s.add_development_dependency 'rubocop', '0.37.0'
 
   s.add_runtime_dependency 'grit', '~> 2.5.0'
   s.add_runtime_dependency 'capistrano', '2.15.7'

--- a/pd-cap-recipes.gemspec
+++ b/pd-cap-recipes.gemspec
@@ -20,7 +20,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'rspec-core'
-  s.add_development_dependency 'guard-rspec'
   s.add_development_dependency 'capistrano-spec', '~> 0.2.0'
   s.add_development_dependency 'rubocop'
 

--- a/pd-cap-recipes.gemspec
+++ b/pd-cap-recipes.gemspec
@@ -17,11 +17,11 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_development_dependency 'bundler', '~> 1.6'
-  s.add_development_dependency 'rake', '10.5.0'
+  s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'rspec-core'
   s.add_development_dependency 'capistrano-spec', '~> 0.2.0'
-  s.add_development_dependency 'rubocop', '0.37.0'
+  s.add_development_dependency 'rubocop'
 
   s.add_runtime_dependency 'grit', '~> 2.5.0'
   s.add_runtime_dependency 'capistrano', '2.15.7'

--- a/pd-cap-recipes.gemspec
+++ b/pd-cap-recipes.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_development_dependency 'bundler', '~> 1.6'
-  s.add_development_dependency 'rake'
+  s.add_development_dependency 'rake', '10.5.0'
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'rspec-core'
   s.add_development_dependency 'capistrano-spec', '~> 0.2.0'


### PR DESCRIPTION
Instead, let individual service owners decide whether to restrict
rollbacks to non-production environments.

This modification is being made as part of SRE-513, in order to enable
deprecation of the deployer user and migration to Igor.